### PR TITLE
OMDI-76 - Add placeholder variables

### DIFF
--- a/ddi-index-pipeline/src/main/resources/common.properties
+++ b/ddi-index-pipeline/src/main/resources/common.properties
@@ -297,6 +297,11 @@ ddi.common.mongo.app.replicaset=${ddi.mongo.replicaset}
 ddi.common.storage.path=${ddi.storage.path}
 
 
+# These are not real values
+ddi.elastic.app.host=localhost
+ddi.elastic.app.port=9200
+ddi.elastic.app.user=omicsdi
+ddi.elastic.app.password=omicsdipass
 ########## ELASTIC SEARCH SETTINGS ######################
 ddi.common.elastic.app.host=${ddi.elastic.app.host}
 ddi.common.elastic.app.port=${ddi.elastic.app.port}


### PR DESCRIPTION
Solves OMDI-76

Put some fake property values to prevent the issue of them missing. It's not a problem since elastic search is not used anymore and values are fake. In the future we might want to remove the code that uses them.